### PR TITLE
build(screenshot-tests): add support for CI and Docker snapshot regeneration

### DIFF
--- a/.github/workflows/screenshot-tests.yaml
+++ b/.github/workflows/screenshot-tests.yaml
@@ -1,8 +1,17 @@
 name: Run screenshot tests
 
 on:
-  push
+  push:
+  workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: "Regenerate snapshots and upload artifacts"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   call-screenshot-tests-workflow:
     uses: netcracker/qubership-apihub-ci/.github/workflows/screenshot-tests.yaml@main
+    with:
+      update_snapshots: ${{ inputs.update_snapshots || false }}

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "build:showcase": "npm run --workspace=@netcracker/qubership-apihub-apispec-view build:showcase",
     "screenshot-test:ci": "npm run --workspace=@netcracker/qubership-apihub-apispec-view screenshot-test:ci",
     "screenshot-test:docker": "npm run --workspace=@netcracker/qubership-apihub-apispec-view screenshot-test:docker",
-    "screenshot-test:regenerate-snapshots": "npm run --workspace=@netcracker/qubership-apihub-apispec-view screenshot-test:regenerate-snapshots",
+    "screenshot-test:regenerate-snapshots:ci": "npm run --workspace=@netcracker/qubership-apihub-apispec-view screenshot-test:regenerate-snapshots:ci",
+    "screenshot-test:regenerate-snapshots:docker": "npm run --workspace=@netcracker/qubership-apihub-apispec-view screenshot-test:regenerate-snapshots:docker",
     "update-lock-file": "update-lock-file @netcracker"
   }
 }

--- a/packages/elements/.config/it/it-test-docker.jest.config.js
+++ b/packages/elements/.config/it/it-test-docker.jest.config.js
@@ -5,6 +5,6 @@ module.exports = prepareJestConfig(
   path.resolve(__dirname, './common-it-test.jest.config.js'),
   path.resolve(__dirname, './common-puppeteer.config.js'),
   {
-    dockerImage: 'ghcr.io/netcracker/qubership-apihub-nodejs-dev-image:1.7.3',
+    dockerImage: 'ghcr.io/netcracker/qubership-apihub-nodejs-dev-image:1.8.0',
   },
 )

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -33,8 +33,10 @@
     "screenshot-test:docker": "start-server-and-test development:local-server:static http://localhost:9009 screenshot-test:run-test:docker",
     "screenshot-test:run-test:ci": "jest --maxWorkers 4 -c .config/it/it-test.jest.config.js",
     "screenshot-test:run-test:docker": "jest --maxWorkers 4 -c .config/it/it-test-docker.jest.config.js",
-    "screenshot-test:regenerate-snapshots": "start-server-and-test development:local-server:static http://localhost:9009 screenshot-test:regenerate-snapshots:run",
-    "screenshot-test:regenerate-snapshots:run": "jest --maxWorkers 4 --updateSnapshot -c .config/it/it-test-docker.jest.config.js",
+    "screenshot-test:regenerate-snapshots:ci": "start-server-and-test development:local-server:static http://localhost:9009 screenshot-test:regenerate-snapshots:run:ci",
+    "screenshot-test:regenerate-snapshots:docker": "start-server-and-test development:local-server:static http://localhost:9009 screenshot-test:regenerate-snapshots:run:docker",
+    "screenshot-test:regenerate-snapshots:run:ci": "jest --maxWorkers 4 --updateSnapshot -c .config/it/it-test.jest.config.js",
+    "screenshot-test:regenerate-snapshots:run:docker": "jest --maxWorkers 4 --updateSnapshot -c .config/it/it-test-docker.jest.config.js",
     "type-check": "tsc --noEmit"
   },
   "rollup": {


### PR DESCRIPTION
- Split snapshot regeneration scripts for CI and Docker
- Update Docker image version to `1.8.0` in test configuration
- Add `workflow_dispatch` for manual trigger in GitHub Actions
- Pass `update_snapshots` input to screenshot tests workflow